### PR TITLE
Hide functionality if exec server is not available.

### DIFF
--- a/che-theia-terminal/src/browser/contribution/theia-docker-exec-terminal-plugin-contribution.ts
+++ b/che-theia-terminal/src/browser/contribution/theia-docker-exec-terminal-plugin-contribution.ts
@@ -8,39 +8,47 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { injectable, inject } from "inversify";
+import { injectable, inject, postConstruct } from "inversify";
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from "@theia/core/lib/common";
 import { CommonMenus } from "@theia/core/lib/browser";
 
 import { TerminalQuickOpenService } from "./terminal-quick-open";
+import { TerminalApiEndPointProvider } from "../workspace/workspace";
 
 export const NewRemoteTerminal = {
     id: 'NewRemoteTerminal',
     label: 'New terminal'
 };
-@injectable()
-export class TheiaDockerExecTerminalPluginCommandContribution implements CommandContribution {
 
-    constructor(
-        @inject(TerminalQuickOpenService) private readonly terminalQuickOpen: TerminalQuickOpenService,
-    ) { }
+@injectable()
+export class TheiaDockerExecTerminalPluginContribution implements CommandContribution, MenuContribution {
+
+    @inject(TerminalQuickOpenService)
+    private readonly terminalQuickOpen: TerminalQuickOpenService;
+
+    @inject("TerminalApiEndPointProvider")
+    protected readonly termApiEndPointProvider: TerminalApiEndPointProvider;
+
+    @postConstruct()
+    protected init(): void {
+    }
 
     registerCommands(registry: CommandRegistry): void {
-        registry.registerCommand(NewRemoteTerminal, {
-            execute: () => {
-                this.terminalQuickOpen.openTerminal();
-            }
+        this.termApiEndPointProvider().then(url => {
+            registry.registerCommand(NewRemoteTerminal, {
+                execute: () => {
+                    this.terminalQuickOpen.openTerminal();
+                }
+            });
         });
     }
-}
-
-@injectable()
-export class TheiaDockerExecTerminalPluginMenuContribution implements MenuContribution {
 
     registerMenus(menus: MenuModelRegistry): void {
-        menus.registerMenuAction(CommonMenus.FILE, {
-            commandId: NewRemoteTerminal.id,
-            label: NewRemoteTerminal.label
+        this.termApiEndPointProvider().then(url => {
+            menus.registerMenuAction(CommonMenus.FILE, {
+                commandId: NewRemoteTerminal.id,
+                label: NewRemoteTerminal.label
+            });
         });
     }
 }

--- a/che-theia-terminal/src/browser/terminal-frontend-module.ts
+++ b/che-theia-terminal/src/browser/terminal-frontend-module.ts
@@ -17,7 +17,7 @@ import { WidgetFactory, ApplicationShell, Widget } from '@theia/core/lib/browser
 import { TerminalQuickOpenService } from "./contribution/terminal-quick-open";
 import { } from './remote';
 import { Workspace, TerminalApiEndPointProvider } from './workspace/workspace';
-import { TheiaDockerExecTerminalPluginCommandContribution, TheiaDockerExecTerminalPluginMenuContribution } from "./contribution/theia-docker-exec-terminal-plugin-contribution";
+import { TheiaDockerExecTerminalPluginContribution } from "./contribution/theia-docker-exec-terminal-plugin-contribution";
 import { RemoteTerminalWidget, REMOTE_TERMINAL_WIDGET_FACTORY_ID, RemoteTerminalWidgetFactoryOptions, RemoteTerminalWidgetOptions } from "./terminal-widget/remote-terminal-widget";
 import { RemoteWebSocketConnectionProvider } from "./server-definition/remote-connection";
 import { TerminalProxyCreator, TerminalProxyCreatorProvider } from "./server-definition/terminal-proxy-creator";
@@ -27,8 +27,8 @@ import 'xterm/lib/xterm.css';
 
 export default new ContainerModule(bind => {
 
-    bind(CommandContribution).to(TheiaDockerExecTerminalPluginCommandContribution);
-    bind(MenuContribution).to(TheiaDockerExecTerminalPluginMenuContribution);
+    bind(CommandContribution).to(TheiaDockerExecTerminalPluginContribution);
+    bind(MenuContribution).to(TheiaDockerExecTerminalPluginContribution);
 
     bind(TerminalQuickOpenService).toSelf();
     bind(RemoteWebSocketConnectionProvider).toSelf();


### PR DESCRIPTION
Hide functionality if exec server is not available. It's useful for demo flow of the workspace next.
Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>