### PR TITLE
Use shell options from terminal widget options or doesn't set up shell at all. Server side should auto-detect it.

### DIFF
--- a/che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
+++ b/che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
@@ -125,13 +125,17 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
     protected async createTerminal(): Promise<number | undefined> {
         const cols = this.term.cols;
         const rows = this.term.rows;
+        let cmd: string[] = [];
+        if (this.options.shellPath) {
+            cmd = [this.options.shellPath, ...this.options.shellArgs || []];
+        }
 
         const machineExec = {
             identifier: {
                 machineName: this.options.machineName,
                 workspaceId: this.options.workspaceId
             },
-            cmd: ["sh"],
+            cmd: cmd,
             cols,
             rows,
             tty: true,

--- a/che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
+++ b/che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
@@ -127,7 +127,7 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
         const rows = this.term.rows;
         let cmd: string[] = [];
         if (this.options.shellPath) {
-            cmd = [this.options.shellPath, ...this.options.shellArgs || []];
+            cmd = [this.options.shellPath, ...(this.options.shellArgs || [])];
         }
 
         const machineExec = {


### PR DESCRIPTION
#  Referenced issue:
https://github.com/eclipse/che/issues/11789 Use /etc/passwd shell field to select the terminal's shell. Use /usr/bin/sh if the shell is not specified

Use shell options from terminal widget options(terminal plugin api) or doesn't set up shell at all. Server side should auto-detect it or set up some default value.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
